### PR TITLE
Improve README to also explicitly enable ChunkID Assignments on the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ It simply checks if the returned `OptionId` is the one used by the mod, and if i
 
 ## Packaging your mod
 
+### Enabling ChunkID assignments
+
+Before you continue, ensure you have **Edit > Editor Preferences > General > Experimental > Allow ChunkID Assignments** checked. Without this, the **Assign to Chunk...** option will not appear.
+
+### Assigning assets to chunks
+
 In this project, we use pak chunks to package your mod files into `.pak` mods.
 
 In the editor, first select all the assets in your mod's folder (shift click or ctrl click, standard stuff works), then right click the highlighted assets and hover over `Asset Actions` -> `Assign to Chunk...` and click on it.


### PR DESCRIPTION
Hi! I don't work with UE actively, in fact this is my first time with it.

Figured we should add this instruction since it's not obvious to first-timers like me. Had to look [for some instructions](https://forums.unrealengine.com/t/chunking-in-ue5-preview-1-not-working-for-windows-platform/503135/3) on how to enable it first. Without it, the "Assign to Chunk" option doesn't show up.